### PR TITLE
Update to use Foobot API Key. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Example
 
     from pyfoobot import Foobot
 
-    fb = Foobot("username", "password")
+    fb = Foobot("API secret key", "username", "password")
     devices = fb.devices()
 
     # Devices is a list, in case you have more than one foobot

--- a/pyfoobot/__init__.py
+++ b/pyfoobot/__init__.py
@@ -46,31 +46,34 @@ class Foobot:
                                                    user=self.username)
         req = self.session.get(url, headers=self.auth_header)
 
-        def create_device(token, device):
+        def create_device(apikey, token, device):
             """Helper to create a FoobotDevice based on a dictionary."""
-            return FoobotDevice(token=token,
+            return FoobotDevice(apikey=apikey,
+				token=token,
                                 user_id=device['userId'],
                                 uuid=device['uuid'],
                                 name=device['name'],
                                 mac=device['mac'])
 
-        return [create_device(self.token, device) for device in req.json()]
+        return [create_device(self.apikey, self.token, device) for device in req.json()]
 
 
 # pylint: disable=too-many-arguments
 class FoobotDevice:
     """Represents a foobot device."""
 
-    def __init__(self, token, user_id, uuid, name, mac):
+    def __init__(self, apikey, token, user_id, uuid, name, mac):
         """Create a foobot device instance used for getting data samples."""
-        self.token = token
+        self.apikey = apikey
+	self.token = token
         self.user_id = user_id
         self.uuid = uuid
         self.name = name
         self.mac = mac
         self.session = requests.Session()
         self.auth_header = {'Accept': 'application/json;charset=UTF-8',
-                            'x-auth-token': self.token}
+                            'x-auth-token': self.token,
+			    'X-API-KEY-TOKEN': self.apikey}
 
     def latest(self):
         """Get latest sample from foobot device."""

--- a/pyfoobot/__init__.py
+++ b/pyfoobot/__init__.py
@@ -16,25 +16,29 @@ BASE_URL = 'https://api.Foobot.io/v2'
 class Foobot:
     """Class for authentication and getting foobot devices."""
 
-    def __init__(self, username, password):
+    def __init__(self, apikey, username, password):
         """Authenticate the username and password."""
+	self.apikey = apikey
         self.username = username
         self.password = password
         self.session = requests.Session()
+
+	self.api_header = {'X-API-KEY-TOKEN': self.apikey}
 
         self.token = self.login()
         if self.token is None:
             raise ValueError("Provided username or password is not valid.")
 
         self.auth_header = {'Accept': 'application/json;charset=UTF-8',
-                            'x-auth-token': self.token}
+                            'x-auth-token': self.token,
+	                    'X-API-KEY-TOKEN': self.apikey}
 
     def login(self):
         """Log into a foobot device."""
         url = '{base}/user/{user}/login/'.format(base=BASE_URL,
                                                  user=self.username)
-        req = self.session.get(url, auth=(self.username, self.password))
-        return req.headers['X-AUTH-TOKEN'] if req.text == "true" else None
+        req = self.session.get(url, auth=(self.username, self.password), headers=self.api_header)
+	return req.headers['X-AUTH-TOKEN'] if req.text == "true" else None
 
     def devices(self):
         """Get list of foobot devices owned by logged in user."""


### PR DESCRIPTION
 #1 

Foobot() syntax changes to require API key as a mandatory argument.

I did not modify the tests.
